### PR TITLE
add kubernetes-volumes

### DIFF
--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,0 +1,115 @@
+# Выполнено ДЗ №1
+
+ - [V] Основное ДЗ
+ - [V] Задание со *
+
+## В процессе сделано:
+ 1. Установила kind
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.18.0/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+
+Создала кластер:
+kind create cluster
+
+$ kind get  clusters
+kind
+
+ 2. Развернула statefulset minio
+
+kubectl apply -f minio-statefulset.yaml
+Сначала создала с одной репликой, проверила создание pv и pvc
+
+Cоздала headless сервис, с указанием clusterIp none
+
+Попробовала увеличить количество реплик до 2, проверила сервисы конечных точек:
+mira@kb1:~$ kubectl get endpoints minio
+NAME    ENDPOINTS                           AGE
+minio   10.244.0.23:9000,10.244.0.24:9000   61m
+
+Создала ещё один под в том же namespace, проверила, что внутри minio резолвится в список тех же адресов:
+/ # host minio
+minio.default.svc.cluster.local has address 10.244.0.23
+minio.default.svc.cluster.local has address 10.244.0.24
+
+Проверила, что сервис работает установкой клиента mc кубернетос:
+kubectl run my-mc -i --tty --image minio/mc:latest --command -- bash
+
+По шаблону подключилась к minio из minio client:
+
+[root@my-mc /]# mc alias set myminio/ https://minio.default.svc.cluster.local MY-USER MY-PASSWORD
+[root@my-mc /]# mc ls myminio/mybucket
+
+[root@my-mc /]#  mc alias set minio/ http://minio.default.svc.cluster.local:9000 minio minio123
+Added `minio` successfully.
+
+Создала backet:
+[root@my-mc /]# mc mb --region --region=us-west-2 minio/mynewbucket
+Bucket created successfully `minio/mynewbucket`.
+
+[root@my-mc /]# mc ls minio/
+[2023-04-01 09:41:16 UTC]     0B mynewbucket/
+
+ 3. Задание с *
+  Настройка secrets:
+  
+  get  MINIO_ACCESS_KEY и MINIO_SECRET_KEY in base64:
+mira@kb1:~/klarissa431_platform/kubernetes-volumes$ echo -n 'minio' | base64
+bWluaW8=
+
+mira@kb1:~/klarissa431_platform/kubernetes-volumes$ echo -n 'minio123' | base64
+bWluaW8xMjM=
+
+Создала secret  kubectl apply -f minio-secret.yaml
+
+Проверила, что успешно создался:
+mira@kb1:$ kubectl get secrets
+NAME            TYPE     DATA   AGE
+minio-secrets   Opaque   2      8s
+
+удалила существующий statefulset 
+
+mira@kb1:$ kubectl delete statefulset minio
+statefulset.apps "minio" deleted
+
+mira@kb1:~$ kubectl get secret minio-secrets  -o jsonpath='{.data}'
+{"MINIO_ACCESS_KEY":"bWluaW8=","MINIO_SECRET_KEY":"bWluaW8xMjM="}
+
+Создала заново kubectl apply -f minio-statefulset-secrets.yaml
+Внутри прописала соответствующие секретс:
+
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-secrets
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-secrets
+              key: MINIO_SECRET_KEY
+
+Заново запустила клиент mc
+Аналогично подключилась к minio командами 
+mc alias set minio/ http://minio.default.svc.cluster.local:9000 minio minio123
+mc ls minio/
+
+Проверила, что клиента успешно подключился с такими данными и смог получить buckets 
+
+
+## Как запустить проект:
+ - Выполнить kubectl apply -f minio-statefulset.yaml
+ - Выполнить kubectl apply -f minio-headless-service.yaml
+
+c *
+ - kubectl apply -f minio-secret.yaml
+ - kubectl apply -f minio-statefulset-secrets.yaml
+ - kubectl apply -f minio-headless-service.yaml
+
+## Как проверить работоспособность:
+ - Запуском mc, настройкой alias и созданием buckets
+
+## PR checklist:
+ - [V] Выставлен label с темой домашнего задания

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secret.yaml
+++ b/kubernetes-volumes/minio-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secrets 
+type: Opaque
+data:
+  MINIO_ACCESS_KEY: bWluaW8= 
+  MINIO_SECRET_KEY: bWluaW8xMjM= 

--- a/kubernetes-volumes/minio-statefulset-secrets.yaml
+++ b/kubernetes-volumes/minio-statefulset-secrets.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 2 
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-secrets 
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-secrets
+              key: MINIO_SECRET_KEY
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1 
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [V] Основное ДЗ
 - [V] Задание со *

## В процессе сделано:
 1. Установила kind

curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.18.0/kind-linux-amd64
chmod +x ./kind
sudo mv ./kind /usr/local/bin/kind

Создала кластер:
kind create cluster

$ kind get  clusters
kind

 2. Развернула statefulset minio

kubectl apply -f minio-statefulset.yaml
Сначала создала с одной репликой, проверила создание pv и pvc

Cоздала headless сервис, с указанием clusterIp none

Попробовала увеличить количество реплик до 2, проверила сервисы конечных точек:
mira@kb1:~$ kubectl get endpoints minio
NAME    ENDPOINTS                           AGE
minio   10.244.0.23:9000,10.244.0.24:9000   61m

Создала ещё один под в том же namespace, проверила, что внутри minio резолвится в список тех же адресов:
/ # host minio
minio.default.svc.cluster.local has address 10.244.0.23
minio.default.svc.cluster.local has address 10.244.0.24

Проверила, что сервис работает установкой клиента mc кубернетос:
kubectl run my-mc -i --tty --image minio/mc:latest --command -- bash

По шаблону подключилась к minio из minio client:

[root@my-mc /]# mc alias set myminio/ https://minio.default.svc.cluster.local MY-USER MY-PASSWORD
[root@my-mc /]# mc ls myminio/mybucket

[root@my-mc /]#  mc alias set minio/ http://minio.default.svc.cluster.local:9000 minio minio123
Added `minio` successfully.

Создала backet:
[root@my-mc /]# mc mb --region --region=us-west-2 minio/mynewbucket
Bucket created successfully `minio/mynewbucket`.

[root@my-mc /]# mc ls minio/
[2023-04-01 09:41:16 UTC]     0B mynewbucket/

 3. Задание с *
  Настройка secrets:

  get  MINIO_ACCESS_KEY и MINIO_SECRET_KEY in base64:
mira@kb1:~/klarissa431_platform/kubernetes-volumes$ echo -n 'minio' | base64
bWluaW8=

mira@kb1:~/klarissa431_platform/kubernetes-volumes$ echo -n 'minio123' | base64
bWluaW8xMjM=

Создала secret  kubectl apply -f minio-secret.yaml

Проверила, что успешно создался:
mira@kb1:$ kubectl get secrets
NAME            TYPE     DATA   AGE
minio-secrets   Opaque   2      8s

удалила существующий statefulset

mira@kb1:$ kubectl delete statefulset minio
statefulset.apps "minio" deleted

mira@kb1:~$ kubectl get secret minio-secrets  -o jsonpath='{.data}'
{"MINIO_ACCESS_KEY":"bWluaW8=","MINIO_SECRET_KEY":"bWluaW8xMjM="}

Создала заново kubectl apply -f minio-statefulset-secrets.yaml
Внутри прописала соответствующие секретс:

        env:
        - name: MINIO_ACCESS_KEY
          valueFrom:
            secretKeyRef:
              name: minio-secrets
              key: MINIO_ACCESS_KEY
        - name: MINIO_SECRET_KEY
          valueFrom:
            secretKeyRef:
              name: minio-secrets
              key: MINIO_SECRET_KEY

Заново запустила клиент mc
Аналогично подключилась к minio командами
mc alias set minio/ http://minio.default.svc.cluster.local:9000 minio minio123
mc ls minio/

Проверила, что клиента успешно подключился с такими данными и смог получить buckets

## Как запустить проект:
 - Выполнить kubectl apply -f minio-statefulset.yaml
 - Выполнить kubectl apply -f minio-headless-service.yaml

c *
 - kubectl apply -f minio-secret.yaml
 - kubectl apply -f minio-statefulset-secrets.yaml
 - kubectl apply -f minio-headless-service.yaml

## Как проверить работоспособность:
 - Запуском mc, настройкой alias и созданием buckets

## PR checklist:
 - [V] Выставлен label с темой домашнего задания